### PR TITLE
Use one room sensor and add different rooms as state attributes

### DIFF
--- a/custom_components/deebot/sensor.py
+++ b/custom_components/deebot/sensor.py
@@ -219,3 +219,8 @@ class DeebotRoomSensor(DeebotBaseSensor):
             return rooms
 
         return None
+
+    @property
+    def icon(self) -> Optional[str]:
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:floor-plan"

--- a/custom_components/deebot/sensor.py
+++ b/custom_components/deebot/sensor.py
@@ -55,8 +55,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             add_devices([DeebotRoomSensor(vacbot, v, typeRooms[v])], True)
 
 
-class DeebotLastCleanImageSensor(Entity):
-    """Deebot Sensor"""
+class DeebotBaseSensor(Entity):
+    """Deebot base sensor"""
 
     def __init__(self, vacbot, device_id):
         """Initialize the Sensor."""
@@ -66,17 +66,25 @@ class DeebotLastCleanImageSensor(Entity):
         self._id = device_id
 
         if self._vacbot.vacuum.get("nick", None) is not None:
-            vacbot_name = "{}".format(self._vacbot.vacuum["nick"])
+            self._vacbot_name = "{}".format(self._vacbot.vacuum["nick"])
         else:
             # In case there is no nickname defined, use the device id
-            vacbot_name = "{}".format(self._vacbot.vacuum["did"])
+            self._vacbot_name = "{}".format(self._vacbot.vacuum["did"])
 
-        self._name = vacbot_name + "_last_clean_image"
+        self._name = self._vacbot_name + "_" + device_id
 
     @property
     def name(self):
         """Return the name of the device."""
         return self._name
+
+
+class DeebotLastCleanImageSensor(DeebotBaseSensor):
+    """Deebot Sensor"""
+
+    def __init__(self, vacbot, device_id):
+        """Initialize the Sensor."""
+        super(DeebotLastCleanImageSensor, self).__init__(vacbot, device_id)
 
     @property
     def state(self):
@@ -90,28 +98,12 @@ class DeebotLastCleanImageSensor(Entity):
         return "mdi:image-search"
 
 
-class DeebotWaterLevelSensor(Entity):
+class DeebotWaterLevelSensor(DeebotBaseSensor):
     """Deebot Sensor"""
 
     def __init__(self, vacbot, device_id):
         """Initialize the Sensor."""
-
-        self._state = STATE_UNKNOWN
-        self._vacbot = vacbot
-        self._id = device_id
-
-        if self._vacbot.vacuum.get("nick", None) is not None:
-            vacbot_name = "{}".format(self._vacbot.vacuum["nick"])
-        else:
-            # In case there is no nickname defined, use the device id
-            vacbot_name = "{}".format(self._vacbot.vacuum["did"])
-
-        self._name = vacbot_name + "_water_level"
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
+        super(DeebotWaterLevelSensor, self).__init__(vacbot, device_id)
 
     @property
     def state(self):
@@ -126,28 +118,12 @@ class DeebotWaterLevelSensor(Entity):
         return "mdi:water"
 
 
-class DeebotComponentSensor(Entity):
+class DeebotComponentSensor(DeebotBaseSensor):
     """Deebot Sensor"""
 
     def __init__(self, vacbot, device_id):
         """Initialize the Sensor."""
-
-        self._state = STATE_UNKNOWN
-        self._vacbot = vacbot
-        self._id = device_id
-
-        if self._vacbot.vacuum.get("nick", None) is not None:
-            vacbot_name = "{}".format(self._vacbot.vacuum["nick"])
-        else:
-            # In case there is no nickname defined, use the device id
-            vacbot_name = "{}".format(self._vacbot.vacuum["did"])
-
-        self._name = vacbot_name + "_" + device_id
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
+        super(DeebotComponentSensor, self).__init__(vacbot, device_id)
 
     @property
     def unit_of_measurement(self):
@@ -171,28 +147,12 @@ class DeebotComponentSensor(Entity):
             return "mdi:air-filter"
 
 
-class DeebotStatsSensor(Entity):
+class DeebotStatsSensor(DeebotBaseSensor):
     """Deebot Sensor"""
 
     def __init__(self, vacbot, device_id):
         """Initialize the Sensor."""
-
-        self._state = STATE_UNKNOWN
-        self._vacbot = vacbot
-        self._id = device_id
-
-        if self._vacbot.vacuum.get("nick", None) is not None:
-            vacbot_name = "{}".format(self._vacbot.vacuum["nick"])
-        else:
-            # In case there is no nickname defined, use the device id
-            vacbot_name = "{}".format(self._vacbot.vacuum["did"])
-
-        self._name = vacbot_name + "_" + device_id
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
+        super(DeebotStatsSensor, self).__init__(vacbot, device_id)
 
     @property
     def unit_of_measurement(self):
@@ -225,29 +185,14 @@ class DeebotStatsSensor(Entity):
         elif self._id == 'stats_type':
             return "mdi:cog"
 
-class DeebotRoomSensor(Entity):
+class DeebotRoomSensor(DeebotBaseSensor):
     """Deebot Sensor"""
 
     def __init__(self, vacbot, roomId, roomDesc):
         """Initialize the Sensor."""
-
-        self._state = STATE_UNKNOWN
-        self._vacbot = vacbot
-        self._id = roomId
+        super(DeebotRoomSensor, self).__init__(vacbot, str(roomId))
         self._desc = roomDesc
-
-        if self._vacbot.vacuum.get("nick", None) is not None:
-            vacbot_name = "{}".format(self._vacbot.vacuum["nick"])
-        else:
-            # In case there is no nickname defined, use the device id
-            vacbot_name = "{}".format(self._vacbot.vacuum["did"])
-
-        self._name = vacbot_name + "_" + roomDesc
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
+        self._name = self._vacbot_name + "_" + roomDesc
 
     @property
     def state(self):


### PR DESCRIPTION
The current version (master) is creating for each possible room a sensor. This leads to many unknown sensor. For example I don't have a room "balcony" set up and I'm also not planning it.

![grafik](https://user-images.githubusercontent.com/26537646/98150344-cb6dd080-1ece-11eb-870b-0e41081258bc.png)

I think it would be better if we have one room sensor. As state it will count the different rooms.
In addition we have the different rooms (which are set up in the ecovacs app) as state attributes.

The advantage of my approach is, that we don't create many unused sensor.
Second the state of a sensor is always a string and will be a string in future HA version. Instead attributes  and templates (HA 0.118+) use native python types. This will simplify a lot the different use-cases in automation and templates.

![grafik](https://user-images.githubusercontent.com/26537646/98150137-7a5ddc80-1ece-11eb-8249-cce23aba6212.png)

For your use-case:
You can access also the attributes of a sensor with node red and therefore it should be no difference. (Except the onetime change to use the attributes)
