### PR TITLE
add room ids back as attributes to the vacuum

### DIFF
--- a/custom_components/deebot/sensor.py
+++ b/custom_components/deebot/sensor.py
@@ -47,13 +47,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         add_devices([DeebotStatsSensor(vacbot, "stats_time")], True)
         add_devices([DeebotStatsSensor(vacbot, "stats_type")], True)
 
-        # Rooms
-        typeRooms = vacbot.getTypeRooms()
-
-        for v in typeRooms:
-            _LOGGER.debug("New room type found: " + typeRooms[v])
-            add_devices([DeebotRoomSensor(vacbot, v, typeRooms[v])], True)
-
 
 class DeebotLastCleanImageSensor(Entity):
     """Deebot Sensor"""
@@ -205,7 +198,7 @@ class DeebotStatsSensor(Entity):
     @property
     def state(self):
         """Return the state of the vacuum cleaner."""
-        
+
         if self._id == 'stats_area' and self._vacbot.stats_area is not None:
             return int(self._vacbot.stats_area)
         elif self._id == 'stats_time'  and self._vacbot.stats_time is not None:
@@ -224,41 +217,3 @@ class DeebotStatsSensor(Entity):
             return "mdi:timer-outline"
         elif self._id == 'stats_type':
             return "mdi:cog"
-
-class DeebotRoomSensor(Entity):
-    """Deebot Sensor"""
-
-    def __init__(self, vacbot, roomId, roomDesc):
-        """Initialize the Sensor."""
-
-        self._state = STATE_UNKNOWN
-        self._vacbot = vacbot
-        self._id = roomId
-        self._desc = roomDesc
-
-        if self._vacbot.vacuum.get("nick", None) is not None:
-            vacbot_name = "{}".format(self._vacbot.vacuum["nick"])
-        else:
-            # In case there is no nickname defined, use the device id
-            vacbot_name = "{}".format(self._vacbot.vacuum["did"])
-
-        self._name = vacbot_name + "_" + roomDesc
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def state(self):
-        """Return the state of the vacuum cleaner."""
-        room = None
-
-        for v in self._vacbot.getSavedRooms():
-            if v['subtype'] == self._desc:
-                if room is None:
-                    room = v['id']
-                else:
-                    room = room + "," + v['id']
-
-        return room

--- a/custom_components/deebot/vacuum.py
+++ b/custom_components/deebot/vacuum.py
@@ -1,14 +1,10 @@
 """Support for Deebot Vaccums."""
-import asyncio
-import logging
-import async_timeout
-import time
-import random
-import string
-import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
-from deebotozmo import *
 import base64
+from typing import Optional, Dict, Any, Union, List
+
+from deebotozmo import *
+from homeassistant.util import slugify
+
 from . import HUB as hub
 
 CONF_COUNTRY = "country"
@@ -66,7 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Deebot vacuums."""
     if DEEBOT_DEVICES not in hass.data:
         hass.data[DEEBOT_DEVICES] = []
-    
+
     for vacbot in hub.vacbots:
         vacuum = DeebotVacuum(hass, vacbot)
         add_devices([vacuum])
@@ -79,7 +75,7 @@ class DeebotVacuum(VacuumEntity):
         self._hass = hass
 
         self.device = vacbot
-        
+
         if self.device.vacuum.get("nick", None) is not None:
             self._name = "{}".format(self.device.vacuum["nick"])
         else:
@@ -94,7 +90,7 @@ class DeebotVacuum(VacuumEntity):
 
     def on_fan_change(self, fan_speed):
         self._fan_speed = fan_speed
-		
+
     @property
     def should_poll(self) -> bool:
         """Return True if entity has to be polled for state."""
@@ -166,7 +162,7 @@ class DeebotVacuum(VacuumEntity):
     async def async_send_command(self, command, params=None, **kwargs):
         """Send a command to a vacuum cleaner."""
         _LOGGER.debug("async_send_command %s (%s), %s", command, params, kwargs)
-        
+
         if command == 'spot_area':
             await self.hass.async_add_executor_job(self.device.SpotArea, params['rooms'], params['cleanings'])
             return
@@ -214,3 +210,28 @@ class DeebotVacuum(VacuumEntity):
                     fh.write(base64.decodebytes(self.device.live_map))
         except KeyError:
             _LOGGER.warning("Can't access local folder: %s", self._live_map_path)
+
+    @property
+    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
+        """Return device specific state attributes.
+
+        Implemented by platform classes. Convention for attribute names
+        is lowercase snake_case.
+        """
+        if self.device.getSavedRooms() is not None:
+            rooms: Dict[str, Union[int, List[int]]] = {}
+            for r in self.device.getSavedRooms():
+                # convert room name to snake_case to meet the convention
+                room_name = "room_" + slugify(r["subtype"])
+                room_values = rooms.get(room_name)
+                if room_values is None:
+                    rooms[room_name] = r["id"]
+                elif isinstance(room_values, list):
+                    room_values.append(r["id"])
+                else:
+                    # Convert from int to list
+                    rooms[room_name] = [room_values, r["id"]]
+
+            return rooms
+
+        return None


### PR DESCRIPTION
Ciao Andrea,

your last change  introduce a sensor for each room with it's id as value. I think most of the enduser will not do anything with it's value and probably we need the ids only for automations and scripts. 
Instead of adding a sensor I would put it back as device attributes for a vacuum. So the relevant information are together at one place. It's also possible to access the attributes from automations and co.
One advantage between state and attribute is, that attributes are not strings but native python types. States will be strings and the HA core team is not planning to add support for native python types in states soon.
This is very helpful if you want only clean one corridor for example. See the templates example below. For strings you manually have to split it by comma.
```
{{ states.vacuum.susi.attributes["room_corridor"] }} Output: [10, 7]
{{ state_attr('vacuum.susi', 'room_corridor') }} Same as above
{{ states.vacuum.susi.attributes["room_corridor"][0] }} Output: 10
```
I'm also pretty sure that you can access attributes from node red.

For the HA admins I think it's more comfortable if all room id's are at one place. As example if you want to call a service over the dev tools.

At the end a screenshot showing the more info dialog. I also set two rooms as corridor to test if a user assigns a room multiple times.
![more_info](https://user-images.githubusercontent.com/26537646/98274427-b0b15f80-1f93-11eb-9949-8de000cce08d.png)

Saluti dall'alto adige :)
