### PR TITLE
Add sensors values as attributes to vacuum entity

### DIFF
--- a/custom_components/deebot/binary_sensor.py
+++ b/custom_components/deebot/binary_sensor.py
@@ -9,12 +9,16 @@ from . import HUB as hub
 _LOGGER = logging.getLogger(__name__)
 
 
+def get_binary_sensors(vacbot: VacBot):
+    return [DeebotMopAttachedBinarySensor(vacbot, "mop_attached")]
+
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Deebot binary sensor platform."""
     hub.update()
 
     for vacbot in hub.vacbots:
-        add_devices([DeebotMopAttachedBinarySensor(vacbot, "mop_attached")], True)
+        add_devices(get_binary_sensors(vacbot), True)
 
 
 class DeebotMopAttachedBinarySensor(BinarySensorEntity):
@@ -37,6 +41,11 @@ class DeebotMopAttachedBinarySensor(BinarySensorEntity):
     def name(self):
         """Return the name of the device."""
         return self._name
+
+    @property
+    def id(self):
+        """Return the internal id"""
+        return self._id
 
     @property
     def is_on(self):

--- a/custom_components/deebot/sensor.py
+++ b/custom_components/deebot/sensor.py
@@ -28,24 +28,42 @@ STATE_CODE_TO_STATE = {
 }
 
 
+def get_general(vacbot: VacBot):
+    return [
+        DeebotLastCleanImageSensor(vacbot, "last_clean_image"),
+        DeebotWaterLevelSensor(vacbot, "water_level")
+    ]
+
+
+def get_components(vacbot: VacBot):
+    return [
+        DeebotComponentSensor(vacbot, COMPONENT_MAIN_BRUSH),
+        DeebotComponentSensor(vacbot, COMPONENT_SIDE_BRUSH),
+        DeebotComponentSensor(vacbot, COMPONENT_FILTER)
+    ]
+
+
+def get_stats(vacbot: VacBot):
+    return [
+        DeebotStatsSensor(vacbot, "stats_area"),
+        DeebotStatsSensor(vacbot, "stats_time"),
+        DeebotStatsSensor(vacbot, "stats_type")
+    ]
+
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Deebot sensor."""
     hub.update()
 
     for vacbot in hub.vacbots:
         # General
-        add_devices([DeebotLastCleanImageSensor(vacbot, "last_clean_image")], True)
-        add_devices([DeebotWaterLevelSensor(vacbot, "water_level")], True)
+        add_devices(get_general(vacbot), True)
 
         # Components
-        add_devices([DeebotComponentSensor(vacbot, COMPONENT_MAIN_BRUSH)], True)
-        add_devices([DeebotComponentSensor(vacbot, COMPONENT_SIDE_BRUSH)], True)
-        add_devices([DeebotComponentSensor(vacbot, COMPONENT_FILTER)], True)
+        add_devices(get_components(vacbot), True)
 
         # Stats
-        add_devices([DeebotStatsSensor(vacbot, "stats_area")], True)
-        add_devices([DeebotStatsSensor(vacbot, "stats_time")], True)
-        add_devices([DeebotStatsSensor(vacbot, "stats_type")], True)
+        add_devices(get_stats(vacbot), True)
 
 
 class DeebotBaseSensor(Entity):
@@ -70,6 +88,11 @@ class DeebotBaseSensor(Entity):
     def name(self):
         """Return the name of the device."""
         return self._name
+
+    @property
+    def id(self):
+        """Return the internal id"""
+        return self._id
 
 
 class DeebotLastCleanImageSensor(DeebotBaseSensor):
@@ -161,8 +184,8 @@ class DeebotStatsSensor(DeebotBaseSensor):
 
         if self._id == 'stats_area' and self._vacbot.stats_area is not None:
             return int(self._vacbot.stats_area)
-        elif self._id == 'stats_time'  and self._vacbot.stats_time is not None:
-            return int(self._vacbot.stats_time/60)
+        elif self._id == 'stats_time' and self._vacbot.stats_time is not None:
+            return int(self._vacbot.stats_time / 60)
         elif self._id == 'stats_type':
             return self._vacbot.stats_type
         else:

--- a/custom_components/deebot/vacuum.py
+++ b/custom_components/deebot/vacuum.py
@@ -1,11 +1,12 @@
 """Support for Deebot Vaccums."""
-import base64
-from typing import Optional, Dict, Any, Union, List
+from typing import Optional, Dict, Any
 
 from deebotozmo import *
 from homeassistant.util import slugify
 
 from . import HUB as hub
+from .binary_sensor import get_binary_sensors
+from .sensor import get_components, get_stats, get_general
 
 CONF_COUNTRY = "country"
 CONF_CONTINENT = "continent"
@@ -16,7 +17,6 @@ CONF_SHOWCOLORROOMS = "show_color_rooms"
 DEEBOT_DEVICES = "deebot_devices"
 
 from homeassistant.components.vacuum import (
-    PLATFORM_SCHEMA,
     STATE_CLEANING,
     STATE_DOCKED,
     STATE_ERROR,
@@ -37,14 +37,14 @@ from homeassistant.components.vacuum import (
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_DEEBOT = (
-    SUPPORT_BATTERY
-    | SUPPORT_FAN_SPEED
-    | SUPPORT_LOCATE
-    | SUPPORT_PAUSE
-    | SUPPORT_RETURN_HOME
-    | SUPPORT_SEND_COMMAND
-    | SUPPORT_START
-    | SUPPORT_STATE
+        SUPPORT_BATTERY
+        | SUPPORT_FAN_SPEED
+        | SUPPORT_LOCATE
+        | SUPPORT_PAUSE
+        | SUPPORT_RETURN_HOME
+        | SUPPORT_SEND_COMMAND
+        | SUPPORT_START
+        | SUPPORT_STATE
 )
 
 STATE_CODE_TO_STATE = {
@@ -58,6 +58,7 @@ STATE_CODE_TO_STATE = {
 
 ATTR_COMPONENT_PREFIX = "component_"
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Deebot vacuums."""
     if DEEBOT_DEVICES not in hass.data:
@@ -66,6 +67,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for vacbot in hub.vacbots:
         vacuum = DeebotVacuum(hass, vacbot)
         add_devices([vacuum])
+
 
 class DeebotVacuum(VacuumEntity):
     """Deebot Vacuums"""
@@ -192,7 +194,7 @@ class DeebotVacuum(VacuumEntity):
             return
 
         if command == 'save_live_map':
-            if(self._live_map != self.device.live_map):
+            if (self._live_map != self.device.live_map):
                 self._live_map = self.device.live_map
                 with open(params['path'], "wb") as fh:
                     fh.write(base64.decodebytes(self.device.live_map))
@@ -204,7 +206,7 @@ class DeebotVacuum(VacuumEntity):
         await self.hass.async_add_executor_job(self.device.request_all_statuses)
 
         try:
-            if(self._live_map != self.device.live_map):
+            if (self._live_map != self.device.live_map):
                 self._live_map = self.device.live_map
                 with open(self._live_map_path, "wb") as fh:
                     fh.write(base64.decodebytes(self.device.live_map))
@@ -218,20 +220,34 @@ class DeebotVacuum(VacuumEntity):
         Implemented by platform classes. Convention for attribute names
         is lowercase snake_case.
         """
+        data = {}
         if self.device.getSavedRooms() is not None:
-            rooms: Dict[str, Union[int, List[int]]] = {}
             for r in self.device.getSavedRooms():
                 # convert room name to snake_case to meet the convention
-                room_name = "room_" + slugify(r["subtype"])
-                room_values = rooms.get(room_name)
+                room_name = f"rooms_{slugify(r['subtype'])}"
+                room_values = data.get(room_name)
                 if room_values is None:
-                    rooms[room_name] = r["id"]
+                    data[room_name] = r["id"]
                 elif isinstance(room_values, list):
                     room_values.append(r["id"])
                 else:
                     # Convert from int to list
-                    rooms[room_name] = [room_values, r["id"]]
+                    data[room_name] = [room_values, r["id"]]
 
-            return rooms
+        for sensor in get_general(self.device):
+            data[sensor.id] = sensor.state
 
-        return None
+        if len(get_stats(self.device)) > 0:
+            for sensor in get_stats(self.device):
+                data[sensor.id] = sensor.state
+
+        if len(get_components(self.device)) > 0:
+            for sensor in get_components(self.device):
+                name = f"components_{sensor.id}"
+                data[name] = sensor.state
+
+        if len(get_binary_sensors(self.device)) > 0:
+            for sensor in get_binary_sensors(self.device):
+                data[sensor.id] = sensor.state
+
+        return data


### PR DESCRIPTION
Most vacuum cards expect that all information about the vacuum are stored within the entity. Therefore add all sensor values as attributes to the vacuum entity.

Fixes https://github.com/And3rsL/Deebotozmo/issues/16
I also plan to use https://github.com/denysdovhan/vacuum-card

@And3rsL Can you release after this merge a new version with https://github.com/And3rsL/Deebotozmo/pull/17, I get annoyed from the 502 warnings :see_no_evil:
Grazie e buone feste