### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Possible values: auto
 example:
 
 entity_id: vacuum.YOUR_ROBOT_NAME
-command: clean
+command: auto_clean
 params:
   type: auto
 ```


### PR DESCRIPTION
Typo in the auto cleaning command name

This command is actually much needed as if you use vacuum.start services while the Deebot is in spotArea stats_type, it doesn't switch to Auto and don't know what to clean, and doesn't move (not sure if bug or intended feature btw...)