### PR TITLE
hacs should download the zip release

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,8 @@
 {
   "name": "Deebot for Home Assistant",
-  "iot_class": "Cloud Polling"
+  "iot_class": "Cloud Polling",
+  "zip_release": true,
+  "filename": "deebot.zip",
+  "hide_default_branch": true,
+  "domain": "deebot"
 }


### PR DESCRIPTION
Hacs should use the zip file otherwise the version stays always to 0.0.0 as we are setting the version during the release action.
Also for that I will hide the default branch. For the feature we cloud use pre-release for testing